### PR TITLE
Upgrade to latest test release, add elytron-oidc-client to cloud-default-config

### DIFF
--- a/eap-cloud-galleon-pack/src/main/resources/layers/standalone/cloud-default-config/layer-spec.xml
+++ b/eap-cloud-galleon-pack/src/main/resources/layers/standalone/cloud-default-config/layer-spec.xml
@@ -17,6 +17,7 @@
         <layer name="jms-activemq"/>
         <layer name="resource-adapters"/>
         <!-- end cloud server -->
+        <layer name="elytron-oidc-client"/>
         <layer name="h2-driver"/>
         <layer name="health"/>
         <layer name="jdr"/>

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,13 @@
     
     <properties>
         <wildfly.cekit.modules.fork>wildfly</wildfly.cekit.modules.fork>
-        <wildfly.cekit.modules.tag>0.27.6</wildfly.cekit.modules.tag>
+        <wildfly.cekit.modules.tag>0.27.9</wildfly.cekit.modules.tag>
         <version.junit>4.13.2</version.junit>
         <!-- version from a test release to unzip in local maven cache -->
-        <version.org.eap>8.0.0.Beta-redhat-20220408</version.org.eap>
-        <!-- should be 19.0.0.Final-redhat-20220408 but is not present in the test release maven repo -->
-        <version.org.wildfly.core>18.0.1.Final-redhat-SNAPSHOT</version.org.wildfly.core>
-        <version.org.wildfly.galleon-plugins>5.2.11.Final</version.org.wildfly.galleon-plugins>
-        <version.org.jboss.eap.maven.plugin>1.0.0.Alpha4-redhat-SNAPSHOT</version.org.jboss.eap.maven.plugin>
+        <version.org.eap>8.0.0.Beta-redhat-20220823</version.org.eap>
+        <version.org.wildfly.core>19.0.0.Beta-redhat-20220823</version.org.wildfly.core>
+        <version.org.wildfly.galleon-plugins>6.0.0.Alpha7</version.org.wildfly.galleon-plugins>
+        <version.org.jboss.eap.maven.plugin>1.0.0.Beta3-redhat-00001</version.org.jboss.eap.maven.plugin>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
* Feature-pack depends on EAP 8 feature-pack that supports Jakarta EE 10.
* Upgraded dependencies to latest artifacts.
* Include elytron-oidc-client in cloud-default-config.