### PR TITLE
Generate channel when building feature-pack

### DIFF
--- a/eap-cloud-galleon-pack/pom.xml
+++ b/eap-cloud-galleon-pack/pom.xml
@@ -94,6 +94,8 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
+                            <generate-channel>true</generate-channel>
+                            <add-feature-packs-as-required-channels>false</add-feature-packs-as-required-channels>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Generate the channel without required dependency on EAP feature-pack. This channel streams, would then have to be merged in the EAP channel.
