### PR TITLE
Upgrade to latest artifacts, 0.27.13 wf-cekit-modules. Last compatible 0.27.x tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,13 @@
     
     <properties>
         <wildfly.cekit.modules.fork>wildfly</wildfly.cekit.modules.fork>
-        <wildfly.cekit.modules.tag>0.27.12</wildfly.cekit.modules.tag>
+        <!-- next tag should come from 0.27.13.x wildfly-cekit branch -->
+        <wildfly.cekit.modules.tag>0.27.13</wildfly.cekit.modules.tag>
         <version.junit>4.13.2</version.junit>
-        <!-- version from a test release to unzip in local maven cache -->
-        <version.org.eap>8.0.0.Beta-redhat-20220923</version.org.eap>
-        <version.org.wildfly.core>19.0.0.Beta16-redhat-00002</version.org.wildfly.core>
+        <version.org.jboss.eap>8.0.0.Beta-redhat-00003</version.org.jboss.eap>
+        <version.org.wildfly.core>19.0.0.Beta16-redhat-00004</version.org.wildfly.core>
         <version.org.wildfly.galleon-plugins>6.2.0.Final-redhat-00001</version.org.wildfly.galleon-plugins>
-        <version.org.jboss.eap.maven.plugin>1.0.0.Beta4-redhat-00001</version.org.jboss.eap.maven.plugin>
+        <version.org.jboss.eap.maven.plugin>1.0.0.Beta5-redhat-00001</version.org.jboss.eap.maven.plugin>
     </properties>
 
     <dependencyManagement>
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>org.jboss.eap</groupId>
                 <artifactId>wildfly-ee-galleon-pack</artifactId>
-                <version>${version.org.eap}</version>
+                <version>${version.org.jboss.eap}</version>
                 <type>zip</type>
             </dependency>
             <!-- tests -->

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -78,7 +78,7 @@
                                 <feature-pack>
                                     <groupId>org.jboss.eap</groupId>
                                     <artifactId>wildfly-ee-galleon-pack</artifactId>
-                                    <version>${version.org.eap}</version>
+                                    <version>${version.org.jboss.eap}</version>
                                 </feature-pack>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
* Upgrade to latest wildfly-cekit-modules and ther dependencies.
* 0.27.13 tag will be the base of a maintenance branch for EAP 8 Beta.