### PR TITLE
Fix for JBEAP-25901, Bring version.txt and JBossEULA.txt to provisioned server when using layers

### DIFF
--- a/eap-cloud-galleon-pack/src/main/resources/configs/standalone/model.xml
+++ b/eap-cloud-galleon-pack/src/main/resources/configs/standalone/model.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+
+<config xmlns="urn:jboss:galleon:config:1.0" model="standalone">
+    <props>
+        <prop name="--server-config" value="standalone.xml"/>
+    </props> 
+    <packages>
+        <package name="wildfly.s2i.common"/>
+        <package name="JBossEULA.txt"/>
+        <package name="version.txt"/>
+    </packages>
+    <layers>
+        <!-- required for termination and script execution -->
+        <include name="core-tools"/>
+        <include name="health"/>
+    </layers>
+</config>

--- a/eap-cloud-galleon-pack/wf-cekit-modules-fp-content-list.txt
+++ b/eap-cloud-galleon-pack/wf-cekit-modules-fp-content-list.txt
@@ -1,4 +1,3 @@
-config
 finalize-script
 launch-common
 launch-openshift


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-25901

Enforce missing packages during provisioning of layers.