### PR TITLE
Fix for JBEAP-28324, http_proxy env var inactive on eap 81 images

### DIFF
--- a/eap-cloud-galleon-pack/pom.xml
+++ b/eap-cloud-galleon-pack/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.jboss.eap.cloud</groupId>
         <artifactId>eap-cloud-galleon-pack-parent</artifactId>
-        <version>1.0.0.Final-redhat-SNAPSHOT</version>
+        <version>2.0.0.Final-redhat-SNAPSHOT</version>
     </parent>
     <artifactId>eap-cloud-galleon-pack</artifactId>
     <packaging>pom</packaging>

--- a/eap-cloud-galleon-pack/src/main/resources/packages/wildfly.s2i.common/content/bin/launch/launch-config.sh
+++ b/eap-cloud-galleon-pack/src/main/resources/packages/wildfly.s2i.common/content/bin/launch/launch-config.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 # Openshift WildFly runtime configuration update
 # Centralised configuration file to set variables that affect the launch scripts in wildfly-cekit-modules.
-
+if [ -f "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options" ]; then
+  local_proxy_options="${JBOSS_CONTAINER_JAVA_PROXY_MODULE}"/proxy-options
+else
+  local_proxy_options="/opt/run-java/proxy-options"
+fi
 # Scripts that 
 # wildfly-cekit-modules will look for each of the listed files and run them if they exist.
 CONFIG_SCRIPT_CANDIDATES=(
@@ -23,7 +27,7 @@ CONFIG_SCRIPT_CANDIDATES=(
   $JBOSS_HOME/bin/launch/oidc.sh
   $JBOSS_HOME/bin/launch/ports.sh
   $JBOSS_HOME/bin/launch/resource-adapter.sh
-  /opt/run-java/proxy-options
+  $local_proxy_options
   $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
   $JBOSS_HOME/bin/launch/statefulset.sh
   # Allow for FP extending this one to add more launch scripts.

--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,13 @@
     
     <properties>
         <wildfly.cekit.modules.fork>wildfly</wildfly.cekit.modules.fork>
-        <wildfly.cekit.modules.tag>0.29.alpha1.3</wildfly.cekit.modules.tag>
+        <wildfly.cekit.modules.tag>0.33.0</wildfly.cekit.modules.tag>
         <version.junit>4.13.2</version.junit>
         <version.inject>1</version.inject>
-        <version.org.jboss.eap>8.0.0.GA-redhat-SNAPSHOT</version.org.jboss.eap>
+        <version.org.jboss.eap>8.0.7.GA-redhat-SNAPSHOT</version.org.jboss.eap>
         <version.org.wildfly.core>21.0.3.Final-redhat-00001</version.org.wildfly.core>
-        <version.org.wildfly.galleon-plugins>6.4.8.Final-redhat-00001</version.org.wildfly.galleon-plugins>
-        <version.org.jboss.eap.maven.plugin>1.0.0.Final-redhat-00001</version.org.jboss.eap.maven.plugin>
+        <version.org.wildfly.galleon-plugins>7.1.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.jboss.eap.maven.plugin>2.0.0.Final-SNAPSHOT</version.org.jboss.eap.maven.plugin>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,11 +25,11 @@
     </parent>
     <groupId>org.jboss.eap.cloud</groupId>
     <artifactId>eap-cloud-galleon-pack-parent</artifactId>
-    <version>1.0.0.Final-redhat-SNAPSHOT</version>
+    <version>2.0.0.Final-redhat-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>Galleon feature-pack for EAP 8 on the Cloud parent</name>
+    <name>Galleon feature-pack for EAP 8.1 on the Cloud parent</name>
   
-    <description>Galleon feature-pack for EAP 8 on the Cloud parent.</description>
+    <description>Galleon feature-pack for EAP 8.1 on the Cloud parent.</description>
 
     <licenses>
         <license>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -79,16 +79,30 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
+                            <channels>
+                                <channel>
+                                <manifest>
+                                    <groupId>org.jboss.eap</groupId>
+                                    <artifactId>wildfly-ee-galleon-pack</artifactId>
+                                    <version>${version.org.jboss.eap}</version>
+                                </manifest>
+                                </channel>
+                                <channel>
+                                <manifest>
+                                    <groupId>org.jboss.eap.cloud</groupId>
+                                    <artifactId>eap-cloud-galleon-pack</artifactId>
+                                    <version>${project.version}</version>
+                                </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <groupId>org.jboss.eap</groupId>
                                     <artifactId>wildfly-ee-galleon-pack</artifactId>
-                                    <version>${version.org.jboss.eap}</version>
                                 </feature-pack>
                                 <feature-pack>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>eap-cloud-galleon-pack</artifactId>
-                                    <version>${project.version}</version>
                                 </feature-pack>
                             </feature-packs>
                         </configuration>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>org.jboss.eap.cloud</groupId>
         <artifactId>eap-cloud-galleon-pack-testsuite-parent</artifactId>
-        <version>1.0.0.Final-redhat-SNAPSHOT</version>
+        <version>2.0.0.Final-redhat-SNAPSHOT</version>
     </parent>
     <artifactId>eap-cloud-galleon-pack-basic-testsuite</artifactId>
-    <name>Galleon feature-pack for EAP 8 on the Cloud basic testsuite</name>
+    <name>Galleon feature-pack for EAP 8.1 on the Cloud basic testsuite</name>
     <description>Simply validate that the server can be provisioned and started (with bare-metal launcher)</description>
 
     <dependencies>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.jboss.eap.cloud</groupId>
         <artifactId>eap-cloud-galleon-pack-parent</artifactId>
-        <version>1.0.0.Final-redhat-SNAPSHOT</version>
+        <version>2.0.0.Final-redhat-SNAPSHOT</version>
     </parent>
     <artifactId>eap-cloud-galleon-pack-testsuite-parent</artifactId>
     <packaging>pom</packaging>
-    <name>Galleon feature-pack for EAP 8 on the Cloud testsuite parent</name>
-    <description>Galleon feature-pack for EAP 8 on the Cloud parent</description>
+    <name>Galleon feature-pack for EAP 8.1 on the Cloud testsuite parent</name>
+    <description>Galleon feature-pack for EAP 8.1 on the Cloud testsuite parent</description>
 
     <properties>
         <management.address>${node0}</management.address>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-28324

Some other changes:
* Next version is 2.0.0.Final-redhat-xxxxx
* Some component upgrades to prepare 8.1
