### PR TITLE
Exclude transitive dependencies from the wildfly-ee feature-pack dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,9 @@
         <wildfly.cekit.modules.tag>0.33.0</wildfly.cekit.modules.tag>
         <version.junit>4.13.2</version.junit>
         <version.inject>1</version.inject>
-        <version.org.jboss.eap>8.0.7.GA-redhat-SNAPSHOT</version.org.jboss.eap>
-        <version.org.wildfly.core>21.0.3.Final-redhat-00001</version.org.wildfly.core>
-        <version.org.wildfly.galleon-plugins>7.1.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.jboss.eap>8.0.5.GA-redhat-00001</version.org.jboss.eap>
+        <version.org.wildfly.core>21.0.9.Final-redhat-00001</version.org.wildfly.core>
+        <version.org.wildfly.galleon-plugins>7.3.1.Final</version.org.wildfly.galleon-plugins>
         <version.org.jboss.eap.maven.plugin>2.0.0.Final-SNAPSHOT</version.org.jboss.eap.maven.plugin>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,12 @@
                 <artifactId>wildfly-ee-galleon-pack</artifactId>
                 <version>${version.org.jboss.eap}</version>
                 <type>zip</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- tests -->
             <dependency>

--- a/testsuite/basic/pom.xml
+++ b/testsuite/basic/pom.xml
@@ -82,9 +82,8 @@
                             <channels>
                                 <channel>
                                 <manifest>
-                                    <groupId>org.jboss.eap</groupId>
-                                    <artifactId>wildfly-ee-galleon-pack</artifactId>
-                                    <version>${version.org.jboss.eap}</version>
+                                    <groupId>org.jboss.eap.channels</groupId>
+                                    <artifactId>eap-8.0</artifactId>
                                 </manifest>
                                 </channel>
                                 <channel>


### PR DESCRIPTION
* Exclude transitive dependencies from the wildfly-ee feature-pack dependency
* Rely on released EAP channels