### PR TITLE
Fix for JBEAP-29412, Deployments configured to autmatically register a SAML client fail to boot because of missing keycloak module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     
     <properties>
         <wildfly.cekit.modules.fork>wildfly</wildfly.cekit.modules.fork>
-        <wildfly.cekit.modules.tag>0.35.0</wildfly.cekit.modules.tag>
+        <wildfly.cekit.modules.tag>0.35.1</wildfly.cekit.modules.tag>
         <version.junit>4.13.2</version.junit>
         <version.inject>1</version.inject>
         <version.org.jboss.eap>8.1.0.Beta-redhat-00001</version.org.jboss.eap>


### PR DESCRIPTION
Upgrade dependency on wildfly-cekit-modules tag that contains fix for the keycloak launch script: https://github.com/wildfly/wildfly-cekit-modules/pull/411
