### PR TITLE
Upgrade to wildfly-cekit-modules 0.29.alpha1.5 to fix keycloak module name: JBEAP-30682

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
     
     <properties>
         <wildfly.cekit.modules.fork>wildfly</wildfly.cekit.modules.fork>
-        <wildfly.cekit.modules.tag>0.29.alpha1.4</wildfly.cekit.modules.tag>
+        <wildfly.cekit.modules.tag>0.29.alpha1.5</wildfly.cekit.modules.tag>
         <version.junit>4.13.2</version.junit>
         <version.inject>1</version.inject>
-        <version.org.jboss.eap>8.0.0.GA-redhat-SNAPSHOT</version.org.jboss.eap>
+        <version.org.jboss.eap>8.0.12.GA-redhat-SNAPSHOT</version.org.jboss.eap>
         <version.org.wildfly.core>21.0.3.Final-redhat-00001</version.org.wildfly.core>
         <version.org.wildfly.galleon-plugins>6.4.8.Final-redhat-00001</version.org.wildfly.galleon-plugins>
         <version.org.jboss.eap.maven.plugin>1.0.0.Final-redhat-00001</version.org.jboss.eap.maven.plugin>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-30682